### PR TITLE
Replace occurences of package.box with ${BOX}.box

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This script will:
 
  1. download the `Debian 7.1 "Wheezy"` server, 64bit iso
  2. ... do some magic to turn it into a vagrant box file
- 3. output `package.box`
+ 3. output `debian-wheezy-64.box`
 
 ## Requirements
 
@@ -22,9 +22,9 @@ This should do everything you need. If you don't have `mkisofs` or `p7zip`, inst
     brew install cdrtools
     brew install p7zip
 
-To add `package.box` with name `debian-71` into vagrant:
+To add `debian-wheezy-64.box` with name `debian-71` into vagrant:
 
-    vagrant box add "debian-71" package.box
+    vagrant box add "debian-71" debian-wheezy-64.box
 
 ## Usage on Linux
 
@@ -35,9 +35,9 @@ This should do everything you need. If you don't have `mkisofs` or `p7zip`:
     sudo apt-get install genisoimage
     sudo apt-get install p7zip-full
 
-To add `package.box` with name `debian-71` into vagrant:
+To add `debian-wheezy-64.box` with name `debian-71` into vagrant:
 
-    vagrant box add "debian-71" package.box
+    vagrant box add "debian-71" debian-wheezy-64.box
 
 ### Notes
 

--- a/build.sh
+++ b/build.sh
@@ -50,9 +50,9 @@ if [ -f "${FOLDER_ISO}/custom.iso" ]; then
   echo "Removing custom iso ..."
   rm "${FOLDER_ISO}/custom.iso"
 fi
-if [ -f "${FOLDER_BASE}/package.box" ]; then
-  echo "Removing old package.box ..."
-  rm "${FOLDER_BASE}/package.box"
+if [ -f "${FOLDER_BASE}/${BOX}.box" ]; then
+  echo "Removing old ${BOX}.box" ...
+  rm "${FOLDER_BASE}/${BOX}.box"
 fi
 if VBoxManage showvminfo "${BOX}" >/dev/null 2>/dev/null; then
   echo "Unregistering vm ..."
@@ -237,7 +237,7 @@ if ! VBoxManage showvminfo "${BOX}" >/dev/null 2>/dev/null; then
 fi
 
 echo "Building Vagrant Box ..."
-vagrant package --base "${BOX}"
+vagrant package --base "${BOX}" --output "${BOX}.box"
 
 # references:
 # http://blog.ericwhite.ca/articles/2009/11/unattended-debian-lenny-install/


### PR DESCRIPTION
In case the user creates and manages different vagrant base boxes,
it is good practise to identify them with a unique name (here: debian-wheezy-64.box based on the value of $BOX )
It does not make the use of the script more complicated for normal users, but will simplify life for power users.
