### PR TITLE
Turns box creation into vanilla debian install

### DIFF
--- a/late_command.sh
+++ b/late_command.sh
@@ -13,9 +13,6 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 # speed up ssh
 echo "UseDNS no" >> /etc/ssh/sshd_config
 
-# get chef
-gem install chef --no-rdoc --no-ri
-
 # display login promt after boot
 sed "s/quiet splash//" /etc/default/grub > /tmp/grub
 sed "s/GRUB_TIMEOUT=[0-9]/GRUB_TIMEOUT=0/" /tmp/grub > /etc/default/grub

--- a/preseed.cfg
+++ b/preseed.cfg
@@ -1,9 +1,9 @@
 ### Localization
 d-i debian-installer/locale string en_US
 d-i debian-installer/language string en
-d-i debian-installer/country string RU
+d-i debian-installer/country string US
 d-i debian-installer/locale string en_US.UTF-8
-d-i localechooser/supported-locales multiselect en_US.UTF-8, ru_RU.UTF-8
+d-i localechooser/supported-locales multiselect en_US.UTF-8
 
 # Keyboard selection.
 d-i console-tools/archs select at
@@ -21,7 +21,7 @@ d-i hw-detect/load_firmware boolean true
 
 ### Mirror settings
 d-i mirror/country string manual
-d-i mirror/http/hostname string ftp.yandex.ru
+d-i mirror/http/hostname string http.debian.net
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i mirror/suite string wheezy
@@ -35,7 +35,7 @@ d-i passwd/user-password-again password vagrant
 
 ### Clock and time zone setup
 d-i clock-setup/utc boolean true
-d-i time/zone string Europe/Moscow
+d-i time/zone string GMT+0
 d-i clock-setup/ntp boolean true
 
 ### Partitioning
@@ -48,18 +48,18 @@ d-i partman/confirm_nooverwrite boolean true
 d-i partman/mount_style select uuid
 
 ### Apt setup
-d-i apt-setup/non-free boolean true
-d-i apt-setup/contrib boolean true
-d-i apt-setup/services-select multiselect security, volatile
+d-i apt-setup/non-free boolean false
+d-i apt-setup/contrib boolean false
+d-i apt-setup/services-select multiselect security
 d-i apt-setup/security_host string security.debian.org
-d-i apt-setup/volatile_host string volatile.debian.org
 
 ### Package selection
 tasksel tasksel/first multiselect
 
-d-i pkgsel/include string openssh-server build-essential nfs-common puppet ruby ruby-dev rubygems ssh ca-certificates curl
+d-i pkgsel/include string openssh-server ssh nfs-common ca-certificates curl puppet chef
 d-i pkgsel/upgrade select safe-upgrade
 
+chef chef/chef_server_url string http://chef.example.com:4000
 popularity-contest popularity-contest/participate boolean false
 
 ### GRUB


### PR DESCRIPTION
https.debian.net is a Debian CDN system so it will pick up the fastest HTTP mirror aroung ( see: http://http.debian.net/ maybe yandex !)

Replace the russian locals with EN
Replace the manual gems install with debian packages for puppet and chef
