### PR TITLE
Uncomment setting MD5 and ISO_GUESTADDITIONS.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,14 +31,14 @@ FOLDER_VBOX="${FOLDER_BUILD}/vbox"
 FOLDER_ISO_CUSTOM="${FOLDER_BUILD}/iso/custom"
 FOLDER_ISO_INITRD="${FOLDER_BUILD}/iso/initrd"
 
-# if [ $OSTYPE = "linux-gnu" ];
-# then
-#   MD5="md5sum"
-#   ISO_GUESTADDITIONS="/usr/share/virtualbox/VBoxGuestAdditions.iso"
-# else
-#   MD5="md5 -q"
-#   ISO_GUESTADDITIONS="/Applications/VirtualBox.app/Contents/MacOS/VBoxGuestAdditions.iso"
-# fi
+if [ $OSTYPE = "linux-gnu" ];
+then
+  MD5="md5sum"
+  ISO_GUESTADDITIONS="/usr/share/virtualbox/VBoxGuestAdditions.iso"
+else
+  MD5="md5 -q"
+  ISO_GUESTADDITIONS="/Applications/VirtualBox.app/Contents/MacOS/VBoxGuestAdditions.iso"
+fi
 
 # start with a clean slate
 if [ -d "${FOLDER_BUILD}" ]; then


### PR DESCRIPTION
Resolves dotzero/vagrant-debian-wheezy-64#11.

Confirmed this works on OSX at least, this was introduced @ 6925c3 but the MD5 variable needs to be set (and it's harmless to set ISO_GUESTADDITIONS with the manual addition commented out).
