### PR TITLE
Permit script to run headless (do not require desktop session).

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -187,7 +187,7 @@ if ! VBoxManage showvminfo "${BOX}" >/dev/null 2>/dev/null; then
     --type hdd \
     --medium "${FOLDER_VBOX}/${BOX}/${BOX}.vdi"
 
-  VBoxManage startvm "${BOX}"
+  VBoxManage startvm "${BOX}" --type headless
 
   echo -n "Waiting for installer to finish "
   while VBoxManage list runningvms | grep "${BOX}" >/dev/null; do


### PR DESCRIPTION
If no Linux desktop session is active, `VBoxManage startvm` can fail with an unclear error message (ref https://www.virtualbox.org/ticket/7367)

```
Waiting for the VM to power on... 
ERROR: The virtual machine 'debian-wheezy-64' has terminated unexpectedly during startup with exit code 0
Details: code NS_ERROR_FAILURE (0x80004005), component Machine, interface IMachine, callee
```

Setting `--type headless` solved this issue for me (Ubuntu precise / 4.1.12_Ubuntur77245, Ubuntu saucy / 4.2.16_Ubuntur86992).

I was not able to replicate this issue when remotely shelled into OSX.
