### PR TITLE
Force hostname, regardless of DHCP or reverse DNS

### DIFF
--- a/preseed.cfg
+++ b/preseed.cfg
@@ -14,6 +14,7 @@ d-i keyboard-configuration/xkb-keymap select us
 ### Network configuration
 d-i netcfg/choose_interface select auto
 d-i netcfg/get_hostname string vagrant-debian-wheezy
+d-i netcfg/hostname string vagrant-debian-wheezy
 d-i netcfg/get_domain string vagrantup.com
 d-i netcfg/wireless_wep string
 


### PR DESCRIPTION
Took me a while to figure this out, but my hostname got set to `10`, probably due to a DHCP server on the network giving `10.x.x.x`. I fixed this by setting `netcfg/hostname` as per the [Wheezy example preseed.cfg](http://www.debian.org/releases/wheezy/example-preseed.txt).
