### PR TITLE
Passwordless sudo as any user

### DIFF
--- a/late_command.sh
+++ b/late_command.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # passwordless sudo
-echo "%sudo   ALL=NOPASSWD: ALL" >> /etc/sudoers
+echo "%sudo   ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # public ssh key for vagrant user
 mkdir /home/vagrant/.ssh


### PR DESCRIPTION
This allows things as `sudo -u postgres` to be done passwordless.

I use Ansible for provisioning which uses `sudo -u` in many patterns. Without this change I have to explicitely supply a password for the `vagrant` user, which is kind of awkward since it has passwordless sudo rights.

The [Vagrant documentation](http://docs.vagrantup.com/v2/boxes/base.html) suggests something similar (look for 'password-less sudo').
