### PR TITLE
use cdn.debian.net to speed up debs download

### DIFF
--- a/preseed.cfg
+++ b/preseed.cfg
@@ -22,7 +22,7 @@ d-i hw-detect/load_firmware boolean true
 
 ### Mirror settings
 d-i mirror/country string manual
-d-i mirror/http/hostname string http.debian.net
+d-i mirror/http/hostname string cdn.debian.net
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i mirror/suite string wheezy


### PR DESCRIPTION
Hi 
a small patch to use cdn.debian.net instead of http.debian.net. Hope you'll merge it.